### PR TITLE
Updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,9 @@ language: python
 dist: xenial
 sudo: false
 python:
-- 2.7
-- 3.5
 - 3.6
 - 3.7
+- 3.8
 install:
 - pip install -e .
 - pip install -r test_requirements.txt

--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,8 @@
 .. image:: https://secure.travis-ci.org/vmalloc/emport.png?branch=master,dev
 
-.. image:: https://pypip.in/d/emport/badge.png
+.. image:: https://img.shields.io/pypi/dm/emport.svg
 
-.. image:: https://pypip.in/v/emport/badge.png
+.. image:: https://img.shields.io/pypi/v/emport.svg
 
 Overview
 ========

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 import os
-import sys
 from setuptools import setup, find_packages
 
 with open(os.path.join(os.path.dirname(__file__), "emport", "__version__.py")) as version_file:
@@ -8,17 +7,12 @@ with open(os.path.join(os.path.dirname(__file__), "emport", "__version__.py")) a
 _INSTALL_REQUIERS = [
     'Logbook>=0.11.0',
 ]
-if sys.version_info < (2, 7):
-    _INSTALL_REQUIERS.append("importlib")
 
 setup(name="emport",
-      classifiers = [
-          "Programming Language :: Python :: 2.6",
-          "Programming Language :: Python :: 2.7",
-          "Programming Language :: Python :: 3.3",
-          "Programming Language :: Python :: 3.4",
-          "Programming Language :: Python :: 3.5",
+      classifiers=[
           "Programming Language :: Python :: 3.6",
+          "Programming Language :: Python :: 3.7",
+          "Programming Language :: Python :: 3.8",
           ],
       description="Utility library for performing programmatic imports",
       license="BSD",


### PR DESCRIPTION
This PR contains 3 commits:
1. Drop support for python version < 3.6
2. Update of README.rst links
3. Use importlib instead of imp, because the latest is deprecated

I dropped support for old python versions because the new importlib is not compatible with them and imp is deprecated with the new versions.